### PR TITLE
Adding command to export to `index.html`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npm run dev
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new) ([Documentation](https://nextjs.org/docs/deployment)).
 
-If you need to deploy it with `index.html`, export it with:
+Export the project to static HTML with:
 ```sh
 npm run export
 ```

--- a/README.md
+++ b/README.md
@@ -30,3 +30,10 @@ npm run dev
 ```
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new) ([Documentation](https://nextjs.org/docs/deployment)).
+
+If you need to deploy it with `index.html`, export it with:
+```sh
+npm run export
+```
+
+`index.html` will be exported in the `out` directory

--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ Export the project to static HTML with:
 npm run export
 ```
 
-`index.html` will be exported in the `out` directory
+This will export `index.html` to the `out` directory.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "next",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "export": "next build && next export"
   },
   "dependencies": {
     "destack": "^0.10.4",


### PR DESCRIPTION
Hey @LiveDuo,

I don't understand `next.js`, but I needed the project to have `index.html` that other web servers could run it. 

I found `next.js` can leverage the `export` command, and it seems to be working fine. Let me know your thoughts.